### PR TITLE
Fix failure limit update bug

### DIFF
--- a/src/WaterLevelSensor.cpp
+++ b/src/WaterLevelSensor.cpp
@@ -1,10 +1,15 @@
 #include "WaterLevelSensor.h"
 
 
-WaterLevelSensor::WaterLevelSensor(int triggerPin, int echoPin, const String nome, unsigned long distMaximaParaAgua, unsigned long distMinimaParaAgua, unsigned int limitfailures, LogManager &logger)
-    : sonar(triggerPin, echoPin, 150), triggerPin(triggerPin), echoPin(echoPin), nome(nome),
-      distanciaMaximaParaAgua(distMaximaParaAgua), distanciaMinimaParaAgua(distMinimaParaAgua), media(0),
-      consecutivefailures(0), limitfailures(limitfailures), logger(logger), status(OK) {
+WaterLevelSensor::WaterLevelSensor(int triggerPin, int echoPin, const String nome,
+                                   unsigned long distMaximaParaAgua,
+                                   unsigned long distMinimaParaAgua,
+                                   unsigned int limitfailures, LogManager &logger)
+    : sonar(triggerPin, echoPin, 150), triggerPin(triggerPin), echoPin(echoPin),
+      nome(nome), distanciaMaximaParaAgua(distMaximaParaAgua),
+      distanciaMinimaParaAgua(distMinimaParaAgua), media(0),
+      leituras{0, 0, 0}, consecutivefailures(0), limitfailures(limitfailures),
+      logger(logger), status(OK) {
 }
 
 void WaterLevelSensor::updateReadings(long novaLeitura)
@@ -89,7 +94,8 @@ void WaterLevelSensor::updateReadings(long novaLeitura)
   int WaterLevelSensor::getStatus() { return status; }
   
   void WaterLevelSensor::setLimitFailures(unsigned int limit){
-    this->consecutivefailures = limit;
+    this->limitfailures = limit;
+    this->consecutivefailures = 0;
   }
   void WaterLevelSensor::setNome(String nome_){
     this->nome = nome_;


### PR DESCRIPTION
## Summary
- initialize `leituras` array for the water level sensor
- fix `setLimitFailures` so it updates the correct variable and resets the counter

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cafbe0f0832b9bf6bb7f82e30b67